### PR TITLE
fix(types): clean up user facing types

### DIFF
--- a/lua/lazyjui.lua
+++ b/lua/lazyjui.lua
@@ -1,2 +1,2 @@
 ---@type lazyjui
-return require("lazyjui")
+return require("lazyjui") ---@return lazyjui

--- a/lua/types.lua
+++ b/lua/types.lua
@@ -58,7 +58,7 @@
 --- in by the user to the `lazyjui.setup` function,
 --- or (if using lazyvim) the `opts` table in the plugin spec.
 ---
----@class lazyjui.Opts: lazyjui.Module
+---@class lazyjui.Opts
 ---
 ---
 ---@field border? lazyjui.Config.Border|nil


### PR DESCRIPTION
# Summary

This merge resolves the LSP warning of `__name` and `__debug` showing up in the user facing types system for `lazy.nvim`'s `opts = {}` field.

## Type of change

> Please delete options that are not relevant.

- [x] - Bug fix (non-breaking change which fixes an issue)
- [x] - Documentation update
