### PR TITLE
Fix typo for health check

### DIFF
--- a/lua/lazyjui/health.lua
+++ b/lua/lazyjui/health.lua
@@ -7,7 +7,7 @@ local M = {
 function M.check()
 	local health = vim.health or require("health")
 	-- Start health check
-	health.start("lazyju.nvim")
+	health.start("lazyjui.nvim")
 
 	-- Check for required plugins
 	if pcall(require, "plenary") then


### PR DESCRIPTION
# Summary

Fix one typo in health check

## Description

`lazyju.nvim` -> `lazyjui.nvim`

## Type of change

- [x] - Documentation update

## Checklist

<details>
  <summary>
    Checklist tick-boxes
  </summary>
<p>

1. Conformity

- [x] - My code follows the style guidelines of this project
- [x] - Code is formatted with `stylua`

1. Best-Effort

- [x] - My changes generate no new warnings or crashes
- [x] - I have performed a self-review of my own code
- [x] - I have commented my code, particularly in hard-to-understand areas

1. Documentation

- [x] - Any documentation that relates to this PR has been updated
    or will be updated in a PR (Link here: )(if applicable)

1. Tests

- [x] - I have added tests that prove my fix is effective or that my feature works
- [x] - New and existing unit tests pass locally with my changes

1. Dependencies

- [x] - Any dependent changes have been merged and published in downstream modules

</p>
</details>
